### PR TITLE
Haul refactor

### DIFF
--- a/nubis/puppet/files/confd/templates/traefik.toml.tmpl
+++ b/nubis/puppet/files/confd/templates/traefik.toml.tmpl
@@ -20,12 +20,12 @@ address = ":8082"
 [consul]
 endpoint = "127.0.0.1:8500"
 watch = true
-prefix = "haul/{{ getv "/config/EnvironmentName" }}/config"
+prefix = "{{ getv "/config/ServiceName" }}/{{ getv "/config/EnvironmentName" }}/config"
 
 [acme]
 # Handle when this isn't set
 email="{{ getv "/config/Email/Destination" }}"
-storage = "haul/{{ getv "/config/EnvironmentName" }}/acme"
+storage = "{{ getv "/config/ServiceName" }}/{{ getv "/config/EnvironmentName" }}/acme"
 entryPoint = "https"
 
 # Only set CA server in stage where this consul key exists

--- a/nubis/puppet/static.pp
+++ b/nubis/puppet/static.pp
@@ -10,6 +10,7 @@ define nubis::static (
   $redirectmatch_regexp=[],
   $redirectmatch_dest=[],
   $rewrites=[],
+  $aliases=[],
   $custom_fragment=undef,
   $directories=undef,
   $error_documents=undef,
@@ -33,7 +34,7 @@ define nubis::static (
     redirectmatch_regexp => $redirectmatch_regexp,
     redirectmatch_dest   => $redirectmatch_dest,
 
-    docroot              => "/data/haul/${title}",
+    docroot              => "/data/${project_name}/${title}",
 
     directoryindex       => join(concat($indexes, $default_indexes), ' '),
 
@@ -48,6 +49,8 @@ define nubis::static (
     access_log_format    => $access_log_format,
 
     headers              => $all_headers,
+
+    aliases              => $aliases,
 
     rewrites             => concat($default_rewrites, $rewrites),
 

--- a/nubis/terraform/consul.tf
+++ b/nubis/terraform/consul.tf
@@ -16,6 +16,13 @@ provider "consul" {
 
 # Publish our outputs into Consul for our application to consume
 resource "consul_keys" "config" {
+
+  key {
+    path    = "${module.consul.config_prefix}/ServiceName"
+    value   = "${var.service_name}"
+    delete  = true
+  }
+
   key {
     path   = "${module.consul.config_prefix}/EnvironmentName"
     value  = "${var.environment}"

--- a/nubis/terraform/sites/main.tf
+++ b/nubis/terraform/sites/main.tf
@@ -39,4 +39,10 @@ resource "consul_keys" "config" {
     value  = "${var.site_git_branches}"
     delete = true
   }
+
+  key {
+    path    = "${module.consul.config_prefix}/sites/${var.site_name}/git_repo"
+    value   = "${var.haul_git_repo}"
+    delete  = true
+  }
 }

--- a/nubis/terraform/sites/variables.tf
+++ b/nubis/terraform/sites/variables.tf
@@ -33,3 +33,7 @@ variable "site_build_frequency" {
 variable "site_git_branches" {
   default = "master"
 }
+
+variable "haul_git_repo" {
+  default = "https://github.com/mozilla-it/haul.git"
+}


### PR DESCRIPTION
This essentially a refactor of parts of haul. Here is a summary on some of the things that have been refactored

- When haul is hard coded somewhere in the code it gets replaced by pulling a value from ServiceName or ${project_name} in puppet
- Added ability to look at a seperate haul repo if we are not using this repo
- Puppet define now can accept aliases