### PR TITLE
Separate out haul ci systems based on environment

### DIFF
--- a/nubis/puppet/ci.pp
+++ b/nubis/puppet/ci.pp
@@ -39,7 +39,7 @@ class { 'jenkins':
   service_ensure     => 'stopped',
   config_hash        => {
     'JENKINS_ARGS' => {
-      'value' => '--webroot=/var/cache/$NAME/war --httpPort=$HTTP_PORT --requestHeaderSize=16384 --prefix=/admin/haul-admin'
+      'value' => '--webroot=/var/cache/$NAME/war --httpPort=$HTTP_PORT --requestHeaderSize=16384 --prefix=/admin/haul-admin-$(nubis-metadata NUBIS_ENVIRONMENT)'
     },
     'JAVA_ARGS'    => {
       'value' => '-Djenkins.install.runSetupWizard=false -Djava.awt.headless=true -Dhudson.diyChunking=false -Dhttp.proxyHost=proxy.service.consul -Dhttp.proxyPort=3128 -Dhttps.proxyHost=proxy.service.consul -Dhttps.proxyPort=3128'

--- a/nubis/puppet/files/svc-haul-admin.json
+++ b/nubis/puppet/files/svc-haul-admin.json
@@ -8,7 +8,7 @@
       "sso=true"
     ],
     "check": {
-       "http": "http://localhost:8080/admin/haul-admin/cc.xml",
+       "http": "http://localhost:8080/admin/haul-admin-%%ENVIRONMENT%%/cc.xml",
        "interval": "10s",
        "timeout": "1s"
     }


### PR DESCRIPTION
This seperates out the CI systems based on stage and prod this should not be merged until nubis platform is update to v2.1.0

Fixes issue #30