### PR TITLE
fixes 44 by specifying EFS cache directory in Planet build script

### DIFF
--- a/sites/planet-mozilla.groovy
+++ b/sites/planet-mozilla.groovy
@@ -9,7 +9,7 @@ node {
   }
 
   stage ('Build') {
-    docker.image('dhartnell/mozilla-planet-builder:4.6').inside("-u 0:0 -e https_proxy=$HTTPS_PROXY -e HTTPS_PROXY -e http_proxy=$HTTP_PROXY -e HTTP_PROXY -v /data/haul/.planet-cache/${env.JOB_NAME}:/data/efs/") {
+    docker.image('dhartnell/mozilla-planet-builder:4.7').inside("-u 0:0 -e https_proxy=$HTTPS_PROXY -e HTTPS_PROXY -e http_proxy=$HTTP_PROXY -e HTTP_PROXY -v /data/haul/.planet-cache/${env.JOB_NAME}:/data/efs/") {
       sh "/usr/local/bin/planet-build.sh planet"
       sh "rsync -aq /data/genericrhel6/src/planet.mozilla.org/ dst/"
     }


### PR DESCRIPTION
As mentioned in issue #44:

>Increase planet.mozilla.org build container from tag 4.6 to 4.7. This container image includes the following Planet build script which stores the build cache for each planet in the EFS mount:

https://github.com/danielhartnell/mozilla-planet-builder/blob/master/planet-build.sh#L76