### PR TITLE
Change Traefik log level to DEBUG

### DIFF
--- a/nubis/puppet/files/confd/templates/traefik.toml.tmpl
+++ b/nubis/puppet/files/confd/templates/traefik.toml.tmpl
@@ -1,5 +1,5 @@
 debug = false
-logLevel = "WARN"
+logLevel = "INFO"
 
 MaxIdleConnsPerHost = 1000
 defaultEntryPoints = ["http","https"]

--- a/nubis/puppet/traefik.pp
+++ b/nubis/puppet/traefik.pp
@@ -44,7 +44,7 @@ upstart::job { 'traefik':
     . /etc/profile.d/proxy.sh
   fi
 
-  exec /usr/local/bin/traefik --web.readonly=true --loglevel=INFO
+  exec /usr/local/bin/traefik --web.readonly=true --loglevel=DEBUG
 ',
     post_stop      => '
 goal=$(initctl status $UPSTART_JOB | awk \'{print $2}\' | cut -d \'/\' -f 1)

--- a/nubis/puppet/traefik.pp
+++ b/nubis/puppet/traefik.pp
@@ -44,7 +44,7 @@ upstart::job { 'traefik':
     . /etc/profile.d/proxy.sh
   fi
 
-  exec /usr/local/bin/traefik --web.readonly=true --loglevel=DEBUG
+  exec /usr/local/bin/traefik --web.readonly=true --loglevel=INFO
 ',
     post_stop      => '
 goal=$(initctl status $UPSTART_JOB | awk \'{print $2}\' | cut -d \'/\' -f 1)


### PR DESCRIPTION
Change Traefik log level to DEBUG for troubleshooting renewals as nothing relevant is showing up at the INFO level.