### PR TITLE
[testing required] implementing new DNS module for ccadb.org

### DIFF
--- a/nubis/terraform/dns.tf
+++ b/nubis/terraform/dns.tf
@@ -10,3 +10,13 @@ resource "aws_route53_delegation_set" "haul-delegation" {
 
   reference_name = "${var.service_name}"
 }
+
+module "ccadb_org" {
+  source                  = "dns"
+  region                  = "${var.region}"
+  environment             = "${var.environment}"
+  service_name            = "${var.service_name}"
+  zone_name               = "ccadb.org"
+  route_53_delegation_set = "${aws_route53_delegation_set.haul-delegation.id}"
+  elb_address             = "${module.load_balancer_web.address}"
+}


### PR DESCRIPTION
This change has not been tested yet. Ideally, I would like to deploy this version of Haul to the nubis-training account and validate the Route 53 configuration. I should be able to do that once I work through this issue:

https://github.com/nubisproject/nubis-builder/issues/267

Once that is complete, we can merge this PR (assuming no errors are found), deploy to stage, test and then promote to production. limed was kind enough to include the nameservers in the Terraform output so we can collect that from Jenkins after stage and prod deploys and update our registrar with that information.