### PR TITLE
removing permanent redirect until the stage site is functional

### DIFF
--- a/nubis/puppet/sites.pp
+++ b/nubis/puppet/sites.pp
@@ -254,7 +254,7 @@ nubis::static { 'seamonkey':
     AddType application/vnd.stardivision.draw .sda
     AddType application/vnd.stardivision.calc .sdc
 
-    Redirect permanent / https://www.seamonkey-project.org/
+    # Redirect permanent / https://www.seamonkey-project.org/
   '
 }
 


### PR DESCRIPTION
This is a temporary change to simplify testing of the stage environment. The redirect (or a similar one) will need to be reintroduced to stage and production before we make the production DNS change.