### PR TITLE
move from svn to git for static.mozilla.com content

### DIFF
--- a/sites/static.groovy
+++ b/sites/static.groovy
@@ -3,10 +3,10 @@
 def nubisStatic = new org.mozilla.nubis.Static()
 
 node {
-   stage('Prep') {
-        checkout([$class: 'SubversionSCM', additionalCredentials: [], excludedCommitMessages: '', excludedRegions: '', excludedRevprop: '', excludedUsers: '', filterChangelog: false, ignoreDirPropChanges: false, includedRegions: '', locations: [[credentialsId: '', depthOption: 'infinity', ignoreExternalsOption: true, local: 'src', remote: 'https://svn.mozilla.org/projects/static.mozilla.com/trunk']], workspaceUpdater: [$class: 'UpdateUpdater']])
-   nubisStatic.prepSite()
-   }
+  stage('Prep') {
+     checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'src/'], [$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '', trackingSubmodules: true], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/mozilla-it/static.mozilla.com.git']]])
+     nubisStatic.prepSite()
+  }
 
   stage ('Build') {
     nubisStatic.buildSite()


### PR DESCRIPTION
I pulled the svn content for the site from [svn.mozilla.org](https://svn.mozilla.org/projects/static.mozilla.com/trunk) and moved it to GitHub:

https://github.com/mozilla-it/static.mozilla.com.git

I believe that this should work correctly. I am actually curious if the top level `trunk` folder is required in the new git repository. If I were to `svn co https://svn.mozilla.org/projects/static.mozilla.com/trunk`, I would end up with that. I'm not sure if that happens when Jenkins checks out the svn repository.

I'm having trouble following the sync logic in Haul to be 100% sure that the same content will end up in the Apache doc root.