### PR TITLE
set forwardedHeaders trusted IPs to empty array

### DIFF
--- a/nubis/puppet/files/confd/templates/traefik.toml.tmpl
+++ b/nubis/puppet/files/confd/templates/traefik.toml.tmpl
@@ -34,7 +34,9 @@ MaxIdleConnsPerHost = 1000
   [entryPoints.https]
     address = ":443"
     [entryPoints.https.tls]
-    MinVersion = "VersionTLS12"
+      MinVersion = "VersionTLS12"
+    [entryPoints.https.forwardedHeaders]
+      trustedIPs = []
 
 [ping]
 [api]


### PR DESCRIPTION
Reference to documentation here:
https://docs.traefik.io/configuration/entrypoints/#forwarded-header

In our environment, Treafik should be explicit in which IPs are allowed to set an `X-Forwarded-*` header. We may need to provide one IP address but I wanted to test the use of an empty array.