### PR TITLE
moving away from an empty array to an invalid IP

### DIFF
--- a/nubis/puppet/files/confd/templates/traefik.toml.tmpl
+++ b/nubis/puppet/files/confd/templates/traefik.toml.tmpl
@@ -36,7 +36,7 @@ MaxIdleConnsPerHost = 1000
     [entryPoints.https.tls]
       MinVersion = "VersionTLS12"
     [entryPoints.https.forwardedHeaders]
-      trustedIPs = []
+      trustedIPs = ["127.0.0.0"]
 
 [ping]
 [api]


### PR DESCRIPTION
Update my previous PR to include an invalid IP address in the `trustedIPs` array.