### PR TITLE
adding CloudFront to Haul with tf module

### DIFF
--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -173,4 +173,3 @@ module "backup" {
   purpose      = "backup"
   role         = "${module.worker.role}"
 }
-

--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -173,3 +173,14 @@ module "backup" {
   purpose      = "backup"
   role         = "${module.worker.role}"
 }
+
+module "cloudfront" {
+  source                 = "github.com/nubisproject/nubis-terraform//cloudfront?ref=131daeedc94660a39fb8de148706070c6d293cf2"
+  region                 = "${var.region}"
+  environment            = "${var.environment}"
+  account                = "${var.account}"
+  service_name           = "${var.service_name}"
+  domain_aliases         = ["www.publicsuffix.org", "publicsuffix.org"]
+  acm_certificate_domain = "publicsuffix.org"
+  load_balancer_web      = "${module.load_balancer_web.name}"
+}

--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -174,13 +174,3 @@ module "backup" {
   role         = "${module.worker.role}"
 }
 
-module "cloudfront" {
-  source                 = "github.com/nubisproject/nubis-terraform//cloudfront?ref=131daeedc94660a39fb8de148706070c6d293cf2"
-  region                 = "${var.region}"
-  environment            = "${var.environment}"
-  account                = "${var.account}"
-  service_name           = "${var.service_name}"
-  domain_aliases         = ["www.publicsuffix.org", "publicsuffix.org"]
-  acm_certificate_domain = "publicsuffix.org"
-  load_balancer_web      = "${module.load_balancer_web.name}"
-}

--- a/nubis/terraform/sites.tf
+++ b/nubis/terraform/sites.tf
@@ -134,8 +134,8 @@ module "publicsuffix" {
 
   site_name = "publicsuffix"
 
-  cloudfront        = true
-  domain_aliases    = ["publicsuffix.org", "www.publicsuffix.org"]
+  cdn               = true
+  domains           = ["publicsuffix.org", "www.publicsuffix.org"]
   load_balancer_web = "${module.load_balancer_web.name}"
 }
 

--- a/nubis/terraform/sites.tf
+++ b/nubis/terraform/sites.tf
@@ -133,6 +133,9 @@ module "publicsuffix" {
   role         = "${module.worker.role}"
 
   site_name = "publicsuffix"
+
+  cloudfront = true
+  domain_aliases = ["publicsuffix.org", "www.publicsuffix.org"]
 }
 
 module "trackertest" {

--- a/nubis/terraform/sites.tf
+++ b/nubis/terraform/sites.tf
@@ -134,8 +134,9 @@ module "publicsuffix" {
 
   site_name = "publicsuffix"
 
-  cloudfront = true
-  domain_aliases = ["publicsuffix.org", "www.publicsuffix.org"]
+  cloudfront        = true
+  domain_aliases    = ["publicsuffix.org", "www.publicsuffix.org"]
+  load_balancer_web = "${module.load_balancer_web.name}"
 }
 
 module "trackertest" {

--- a/nubis/terraform/sites/main.tf
+++ b/nubis/terraform/sites/main.tf
@@ -9,15 +9,15 @@ module "consul" {
 
 # If needed, CloudFront is configured for the site
 module "cloudfront" {
-  count = "${var.cloudfront ? 1 : 0}"
+  count = "${var.cdn ? 1 : 0}"
 
   source                 = "github.com/nubisproject/nubis-terraform//cloudfront?ref=131daeedc94660a39fb8de148706070c6d293cf2"
   region                 = "${var.region}"
   environment            = "${var.environment}"
   account                = "${var.account}"
   service_name           = "${var.service_name}"
-  domain_aliases         = "${var.domain_aliases}"
-  acm_certificate_domain = "${var.domain_aliases[0]}"
+  domains                = "${var.domains}"
+  acm_certificate_domain = "${var.domains[0]}"
   load_balancer_web      = "${var.load_balancer_web}"
 }
 

--- a/nubis/terraform/sites/main.tf
+++ b/nubis/terraform/sites/main.tf
@@ -8,18 +8,17 @@ module "consul" {
 }
 
 # If needed, CloudFront is configured for the site
-module "cloudfront"
-{
+module "cloudfront" {
   count = "${var.cloudfront ? 1 : 0}"
 
-  source = "github.com/nubisproject/nubis-terraform//cloudfront?ref=131daeedc94660a39fb8de148706070c6d293cf2"
+  source                 = "github.com/nubisproject/nubis-terraform//cloudfront?ref=131daeedc94660a39fb8de148706070c6d293cf2"
   region                 = "${var.region}"
   environment            = "${var.environment}"
   account                = "${var.account}"
   service_name           = "${var.service_name}"
   domain_aliases         = "${var.domain_aliases}"
   acm_certificate_domain = "${var.domain_aliases[0]}"
-  load_balancer_web      = "${module.load_balancer_web.name}"
+  load_balancer_web      = "${var.load_balancer_web}"
 }
 
 # Configure our Consul provider, module can't do it for us

--- a/nubis/terraform/sites/main.tf
+++ b/nubis/terraform/sites/main.tf
@@ -7,6 +7,21 @@ module "consul" {
   service_name = "${var.service_name}"
 }
 
+# If needed, CloudFront is configured for the site
+module "cloudfront"
+{
+  count = "${var.cloudfront ? 1 : 0}"
+
+  source = "github.com/nubisproject/nubis-terraform//cloudfront?ref=131daeedc94660a39fb8de148706070c6d293cf2"
+  region                 = "${var.region}"
+  environment            = "${var.environment}"
+  account                = "${var.account}"
+  service_name           = "${var.service_name}"
+  domain_aliases         = "${var.domain_aliases}"
+  acm_certificate_domain = "${var.domain_aliases[0]}"
+  load_balancer_web      = "${module.load_balancer_web.name}"
+}
+
 # Configure our Consul provider, module can't do it for us
 provider "consul" {
   address    = "${module.consul.address}"

--- a/nubis/terraform/sites/variables.tf
+++ b/nubis/terraform/sites/variables.tf
@@ -34,10 +34,10 @@ variable "haul_git_repo" {
   default = "https://github.com/mozilla-it/haul.git"
 }
 
-variable "cloudfront" {
+variable "cdn" {
   default = false
 }
 
-variable "domain_aliases" {}
+variable "domains" {}
 
 variable "load_balancer_web" {}

--- a/nubis/terraform/sites/variables.tf
+++ b/nubis/terraform/sites/variables.tf
@@ -40,3 +40,4 @@ variable "cloudfront" {
 
 variable "domain_aliases" {}
 
+variable "load_balancer_web" {}

--- a/nubis/terraform/sites/variables.tf
+++ b/nubis/terraform/sites/variables.tf
@@ -33,3 +33,10 @@ variable "site_git_branches" {
 variable "haul_git_repo" {
   default = "https://github.com/mozilla-it/haul.git"
 }
+
+variable "cloudfront" {
+  default = false
+}
+
+variable "domain_aliases" {}
+


### PR DESCRIPTION
Before this is merged, I'll need someone to request the ACM certificate with a CN of publicsuffix.org and an alt name that covers the `www` subdomain. The Terraform module will use the following to lookup the ACM cert ARN based on the `acm_certificate_domain` value seen in this change (publicsuffix.org).

```
data "aws_acm_certificate" "acm_tf" {
  domain   = "${var.acm_certificate_domain}"
  statuses = ["ISSUED"]
}
```