### PR TITLE
WIP - adding DNS in Route 53 for experiencethearch.com

### DIFF
--- a/nubis/terraform/dns.tf
+++ b/nubis/terraform/dns.tf
@@ -11,7 +11,7 @@ resource "aws_route53_delegation_set" "haul-delegation" {
   reference_name = "${var.service_name}"
 }
 
-module "experiencethearch.com" {
+module "experiencethearch_com" {
   source                 = "dns"
   region                 = "${var.region}"
   environment            = "${var.environment}"

--- a/nubis/terraform/dns.tf
+++ b/nubis/terraform/dns.tf
@@ -11,6 +11,18 @@ resource "aws_route53_delegation_set" "haul-delegation" {
   reference_name = "${var.service_name}"
 }
 
+module "experiencethearch.com" {
+  source                 = "dns"
+  region                 = "${var.region}"
+  environment            = "${var.environment}"
+  service_name           = "${var.service_name}"
+  route53_delegation_set = "${aws_route53_delegation_set.haul-delegation.id}"
+  hosted_zone_ttl        = "3600"
+  elb_address            = "${module.load_balancer_web.address}"
+
+  zone_name = "${var.environment == "prod" ? "experiencethearch.com" : join(".", list(var.environment, "experiencethearch.com"))}"
+}
+
 module "ccadb_org" {
   source                 = "dns"
   region                 = "${var.region}"


### PR DESCRIPTION
We should discuss this tomorrow and see if we want to use Route 53 for DNS. If we do, the PR to use our DNS module is ready to go.