### PR TITLE
set no-cache cache control for experiencethearch

### DIFF
--- a/nubis/puppet/sites.pp
+++ b/nubis/puppet/sites.pp
@@ -355,7 +355,7 @@ nubis::static { 'experiencethearch':
     'www.experiencethearch.com',
   ],
 
-  headers => [
+  headers       => [
     'set Cache-Control "no-cache"',
   ],
 }

--- a/nubis/puppet/sites.pp
+++ b/nubis/puppet/sites.pp
@@ -354,4 +354,8 @@ nubis::static { 'experiencethearch':
     'experiencethearch.mozilla.org',
     'www.experiencethearch.com',
   ],
+
+  headers => [
+    'set Cache-Control "no-cache"',
+  ],
 }


### PR DESCRIPTION
This will help the development team to get a faster feedback loop while they continue to develop. We would like to deploy this to production for now but we intend to restore the default `Cache-Control max-age` of `1800` seconds in a few days.