### PR TITLE
force user to provide name for ACM certificate

### DIFF
--- a/nubis/terraform/sites.tf
+++ b/nubis/terraform/sites.tf
@@ -132,9 +132,10 @@ module "publicsuffix" {
   service_name = "${var.service_name}"
   role         = "${module.worker.role}"
 
-  enable_cdn        = true
-  domain_aliases    = ["publicsuffix.org", "www.publicsuffix.org"]
-  load_balancer_web = "${module.load_balancer_web.address}"
+  enable_cdn             = true
+  domain_aliases         = ["publicsuffix.org", "www.publicsuffix.org"]
+  acm_certificate_domain = "publicsuffix.org"
+  load_balancer_web      = "${module.load_balancer_web.address}"
 
   site_name = "publicsuffix"
 }

--- a/nubis/terraform/sites/main.tf
+++ b/nubis/terraform/sites/main.tf
@@ -15,7 +15,7 @@ module "cloudfront" {
   account                = "${var.account}"
   service_name           = "${var.service_name}"
   load_balancer_web      = "${var.load_balancer_web}"
-  acm_certificate_domain = "${var.domain_aliases[0]}"
+  acm_certificate_domain = "${var.acm_certificate_domain}"
   domain_aliases         = "${var.domain_aliases}"
 }
 

--- a/nubis/terraform/sites/variables.tf
+++ b/nubis/terraform/sites/variables.tf
@@ -31,6 +31,10 @@ variable "load_balancer_web" {
   default = ""
 }
 
+variable "acm_certificate_domain" {
+  default = ""
+}
+
 variable "site_poll_frequency" {
   default = "H/10 * * * *"
 }


### PR DESCRIPTION
We're seeing the following in our deployments. This PR should address that specific issue. For the time being, I would prefer to provide the certificate name manually rather than assuming the first element in the `domain_aliases` list contains the right name.

```
14:03:06 Error: module.static.module.cloudfront.var.acm_certificate_domain: At column 21, line 1: list "var.domain_aliases" does not have any elements so cannot determine type. in:
14:03:06 
14:03:06 ${var.domain_aliases[0]}
14:03:06 
14:03:06 
14:03:06 
14:03:06 Error: module.seamonkey.module.cloudfront.var.acm_certificate_domain: At column 21, line 1: list "var.domain_aliases" does not have any elements so cannot determine type. in:
14:03:06 
14:03:06 ${var.domain_aliases[0]}
14:03:06 
14:03:06 
14:03:06 
```

After several failures with this work, I'll go back to getting Haul deployed into a training or development account so we can effectively test before merging.