### PR TITLE
removed unused response headers

### DIFF
--- a/nubis/puppet/sites.pp
+++ b/nubis/puppet/sites.pp
@@ -338,7 +338,7 @@ nubis::static { 'mozqa':
     rewrite_rule => [ '^/ca/ssl-md5-mozqa-ca.pem$ - [T=application/x-x509-ca-cert]' ],
   },
   ],
-  headers             => [
+  headers       => [
     "set X-Nubis-Version ${project_version}",
     "set X-Nubis-Project ${project_name}",
     "set X-Nubis-Build   ${packer_build_name}",

--- a/nubis/puppet/sites.pp
+++ b/nubis/puppet/sites.pp
@@ -338,6 +338,12 @@ nubis::static { 'mozqa':
     rewrite_rule => [ '^/ca/ssl-md5-mozqa-ca.pem$ - [T=application/x-x509-ca-cert]' ],
   },
   ],
+  headers             => [
+    "set X-Nubis-Version ${project_version}",
+    "set X-Nubis-Project ${project_name}",
+    "set X-Nubis-Build   ${packer_build_name}",
+    'set Access-Control-Allow-Origin "*"',
+  ],
 }
 
 nubis::static { 'dynamicua':


### PR DESCRIPTION
This will bring us down from a B to an F in Observatory temporarily. We will match what is in production today until I can work with the site owner to see which headers can be added. Since the domain is used for testing / QA, there may be some response headers we cannot set. The Apache configuration does state that we cannot set HSTS for example.