### PR TITLE
removing references to CloudFront module

### DIFF
--- a/nubis/terraform/sites.tf
+++ b/nubis/terraform/sites.tf
@@ -132,11 +132,6 @@ module "publicsuffix" {
   service_name = "${var.service_name}"
   role         = "${module.worker.role}"
 
-  enable_cdn             = true
-  domain_aliases         = ["publicsuffix.org", "www.publicsuffix.org"]
-  acm_certificate_domain = "publicsuffix.org"
-  load_balancer_web      = "${module.load_balancer_web.address}"
-
   site_name = "publicsuffix"
 }
 

--- a/nubis/terraform/sites/main.tf
+++ b/nubis/terraform/sites/main.tf
@@ -7,18 +7,6 @@ module "consul" {
   service_name = "${var.service_name}"
 }
 
-module "cloudfront" {
-  source                 = "github.com/nubisproject/nubis-terraform//cloudfront?ref=685e9714ec80afb3c42ee3ce6b7f641b65f33349"
-  enabled                = "${var.enable_cdn}"
-  region                 = "${var.region}"
-  environment            = "${var.environment}"
-  account                = "${var.account}"
-  service_name           = "${var.service_name}"
-  load_balancer_web      = "${var.load_balancer_web}"
-  acm_certificate_domain = "${var.acm_certificate_domain}"
-  domain_aliases         = "${var.domain_aliases}"
-}
-
 # Configure our Consul provider, module can't do it for us
 provider "consul" {
   address    = "${module.consul.address}"

--- a/nubis/terraform/sites/variables.tf
+++ b/nubis/terraform/sites/variables.tf
@@ -18,23 +18,6 @@ variable "role" {}
 
 variable "site_name" {}
 
-variable "domain_aliases" {
-  type    = "list"
-  default = []
-}
-
-variable "enable_cdn" {
-  default = false
-}
-
-variable "load_balancer_web" {
-  default = ""
-}
-
-variable "acm_certificate_domain" {
-  default = ""
-}
-
 variable "site_poll_frequency" {
   default = "H/10 * * * *"
 }


### PR DESCRIPTION
We can add this module back in later. It was being tested in Haul and it really should have been tested in a version of Haul in a testing account.