### PR TITLE
fixing www subdomain for extensiontest.com

### DIFF
--- a/nubis/terraform/dns.tf
+++ b/nubis/terraform/dns.tf
@@ -125,6 +125,7 @@ module "extensiontest_com" {
   route53_delegation_set = "${aws_route53_delegation_set.haul-delegation.id}"
   hosted_zone_ttl        = "3600"
   elb_address            = "${module.load_balancer_web.address}"
+  www_dest               = "www.extensiontest.com.herokudns.com"
 
   # Make sure to construct a unique zone name depending on the environment
   zone_name = "${var.environment == "prod" ? "extensiontest.com" : join(".", list(var.environment, "extensiontest.com.allizom.org"))}"


### PR DESCRIPTION
This fixes Bugzilla 1489293. The www subdomain needs to CNAME to the right host. Once this is promoted to prod we can test to see if we still see certificate issues.