### PR TITLE
Revert "adding new virtualhosts for additional start domains"

### DIFF
--- a/nubis/puppet/files/confd/templates/traefik.toml.tmpl
+++ b/nubis/puppet/files/confd/templates/traefik.toml.tmpl
@@ -104,24 +104,6 @@ main = "dynamicua-origin.mozilla.org"
 main = "start.mozilla.org"
 
 [[acme.domains]]
-main = "start.mozilla.com"
-sans = [
-  "start-prod.mozilla.com"
-]
-
-[[acme.domains]]
-main = "*.start.mozilla.com"
-
-[[acme.domains]]
-main = "*.start2.mozilla.com"
-
-[[acme.domains]]
-main = "*.start3.mozilla.com"
-
-[[acme.domains]]
-main = "*.start-prod.mozilla.com"
-
-[[acme.domains]]
 main = "www.mozqa.com"
 sans = [
   "mozqa.com"

--- a/nubis/puppet/sites.pp
+++ b/nubis/puppet/sites.pp
@@ -37,38 +37,6 @@ nubis::static { 'planet-bugzilla':
   ],
 }
 
-nubis::static { 'local-start':
-  servername      => 'en-us.start.mozilla.org',
-  serveraliases   => [
-    '*.start.mozilla.com',
-    '*.start2.mozilla.com',
-    '*.start3.mozilla.com',
-    '*.start-prod.mozilla.com',
-  ],
-  custom_fragment => '
-    ExpiresActive On
-    ExpiresDefault "access plus 1 year"
-
-    RewriteEngine On
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{HTTP_HOST} ^([a-z]{2,3})(-[a-z]{2})?\.(start.*)$
-    RewriteMap uppercase int:toupper
-    RewriteRule ^ http://start.mozilla.org/%1${uppercase:%2}/? [R=301,L]
-  '
-}
-
-nubis::static { 'start-com-redirect':
-  servername      => 'start.mozilla.com',
-  serveraliases   => [
-    'start-prod.mozilla.com',
-  ],
-  custom_fragment => '
-    Redirect permanent / http://start.mozilla.org/
-    ExpiresActive On
-    ExpiresDefault "access plus 1 year"
-  '
-}
-
 nubis::static { 'start':
   servername      => 'start.mozilla.org',
   serveraliases   => [


### PR DESCRIPTION
Reverts mozilla-it/haul#164

We were unable to immediately support the required wildcard certificates so we moved the hosting of these redirects elsewhere. I am reverting this PR because the changes are currently unused.